### PR TITLE
update git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Visual Studio needs the `Desktop development with C++` workload with the `MSVC v
 
 ```bash
 # With HTTPS:
-git clone --recursive https://github.com/openmultiplayer/pawn-template
+git clone --recursive https://github.com/openmultiplayer/basic-template.git
 # With SSH:
-git clone --recursive git@github.com:openmultiplayer/pawn-template
+git clone --recursive git@github.com:openmultiplayer/basic-template.git
 ```
 
 Note the use of the `--recursive` argument, because this repository contains submodules.  A useful setting when cloning recursive repos is:


### PR DESCRIPTION
The above URL was pointing to `pawn-template` repo instead of `basic-template`.